### PR TITLE
install gcc dependency for fan control on Ubuntu OS (64 bit).

### DIFF
--- a/install-ubuntu-64.sh
+++ b/install-ubuntu-64.sh
@@ -23,6 +23,7 @@ sudo sed -i '$a\dtoverlay=dwc2,dr_mode=host' /boot/firmware/config.txt
 
 # install PWM fan control daemon.
 log_action_msg "DeskPi main control service loaded."
+sudo apt-get install -qy gcc
 cd $installationfolder/drivers/c/ 
 mv $installationfolder/drivers/c/pwmFanControl $installationfolder/drivers/c/pwmFanControl.old
 gcc -o $installationfolder/drivers/c/pwmFanControl $installationfolder/drivers/c/pwmControlFan.c


### PR DESCRIPTION
The standard installation of Ubuntu does not include gcc, so outputs an error when running the following:
`gcc -o $installationfolder/drivers/c/pwmFanControl $installationfolder/drivers/c/pwmControlFan.c`  
This PR simply adds the command to install gcc before this step. If gcc is already installed it will continue without error.
