### PR TITLE
suppress error on mv - Ubuntu OS (64 bit).

### DIFF
--- a/install-ubuntu-64.sh
+++ b/install-ubuntu-64.sh
@@ -24,7 +24,7 @@ sudo sed -i '$a\dtoverlay=dwc2,dr_mode=host' /boot/firmware/config.txt
 # install PWM fan control daemon.
 log_action_msg "DeskPi main control service loaded."
 cd $installationfolder/drivers/c/ 
-mv $installationfolder/drivers/c/pwmFanControl $installationfolder/drivers/c/pwmFanControl.old
+mv $installationfolder/drivers/c/pwmFanControl $installationfolder/drivers/c/pwmFanControl.old 2>/dev/null
 gcc -o $installationfolder/drivers/c/pwmFanControl $installationfolder/drivers/c/pwmControlFan.c
 sudo cp -rf $installationfolder/drivers/c/pwmFanControl /usr/bin/pwmFanControl
 sudo cp -rf $installationfolder/drivers/c/fanStop  /usr/bin/fanStop


### PR DESCRIPTION
When the script is first run, this step outputs an error as the file will not exist.
`mv $installationfolder/drivers/c/pwmFanControl $installationfolder/drivers/c/pwmFanControl.old`
This PR adds `2>/dev/null` to the end of the line to suppress the error. `mv` does not output a message for successful completion, so this does not interfere with any success messages.
