### PR TITLE
drivers/c/pwmControlFan.c: Fix NULL pointer deref

### DIFF
--- a/drivers/c/pwmControlFan.c
+++ b/drivers/c/pwmControlFan.c
@@ -137,8 +137,8 @@ int main(void){
 					conf_info[i] = atoi(buffer);
 				}
 			}
+			fclose(fp);
 		}
-		fclose(fp);
 
 		/* Testing section
 		  for(i=0;i<8;i++)


### PR DESCRIPTION
The reason why most if not all of the bug reports complain about this segfaulting is because this app segfaults if there is no config file.

This unfortunately doesn't solve the root causes that most people encounter, but this should remove some noise in all the issues.